### PR TITLE
IOSP-5535: New prefix RNFetchBlob-custom added

### DIFF
--- a/ios/RNFetchBlobReqBuilder.h
+++ b/ios/RNFetchBlobReqBuilder.h
@@ -11,6 +11,10 @@
 
 #import <Foundation/Foundation.h>
 
+@protocol RNFetchBlobCustomFile <NSObject>
+-(void) readFile:(NSString *)content onComplete:(void(^)(NSData * formData, NSString *error))onComplete;
+@end
+
 @interface RNFetchBlobReqBuilder : NSObject;
 
 +(void) buildMultipartRequest:(NSDictionary *)options

--- a/ios/RNFetchBlobReqBuilder.m
+++ b/ios/RNFetchBlobReqBuilder.m
@@ -251,7 +251,12 @@
                     NSArray<NSTextCheckingResult *>* matches = [regex matchesInString:content options:0 range:matchRange];
                     if ([matches count] >= 1) {
                         NSString *customClassName = [content substringWithRange:[matches[0] rangeAtIndex:1]];
-                        id<RNFetchBlobCustomFile> fileReader = [[NSClassFromString(customClassName) alloc] init];
+                        Class customClass = NSClassFromString(customClassName);
+                        if (customClass == nil) {
+                            onComplete(formData, YES);
+                            return;
+                        }
+                        id<RNFetchBlobCustomFile> fileReader = [[customClass alloc] init];
                         [fileReader readFile:content onComplete:afterReadFile];
                         return;
                     }

--- a/ios/RNFetchBlobReqBuilder.m
+++ b/ios/RNFetchBlobReqBuilder.m
@@ -241,8 +241,22 @@
                             getFieldData = nil;
                         }
                     };
+
+                    // Example prefix: RNFetchBlob-custom:SMCryptoFile://cmxkCg==@/Containers/Data/Application/Cache/112233.jpg
+                    NSRange matchRange = NSMakeRange(0, [content length]);
+                    NSRegularExpression* regex =
+                        [NSRegularExpression regularExpressionWithPattern:@"^RNFetchBlob-custom:([a-zA-z]+)://"
+                                                                  options:0
+                                                                    error:nil];
+                    NSArray<NSTextCheckingResult *>* matches = [regex matchesInString:content options:0 range:matchRange];
+                    if ([matches count] >= 1) {
+                        NSString *customClassName = [content substringWithRange:[matches[0] rangeAtIndex:1]];
+                        id<RNFetchBlobCustomFile> fileReader = [[NSClassFromString(customClassName) alloc] init];
+                        [fileReader readFile:content onComplete:afterReadFile];
+                        return;
+                    }
                     // append data from file asynchronously
-                    if([content hasPrefix:FILE_PREFIX])
+                    else if([content hasPrefix:FILE_PREFIX])
                     {
                         NSString * orgPath = [content substringFromIndex:[FILE_PREFIX length]];
                         orgPath = [RNFetchBlobFS getPathOfAsset:orgPath];


### PR DESCRIPTION
According to doc, user can use ```RNFetchBlob-file://``` prefix to order native to directly upload a file in the filesystem to an upload API.

This change added one more prefix, ```RNFetchBlob-custom:...://```, it has some more features.  The prefix can be specified as below:

```
RNFetchBlob-custom:<classname>://<params_for_class>
```
An example is like below:
```
RNFetchBlob-custom:SMCryptoFile://cmxkCg==@/Containers/Data/Application/Cache/112233.jpg
```

With the above example, the library will now try to instantiate an instance of classname ```SMCryptoFile```.  This class is expected to implement the ```RNFetchBlobCustomFile``` protocol, and the entire string is passed into instance of this class for processing.  The instance will interpret ```params_for_class```. In the above example, the parameters are the decryption key and the file path