### PR TITLE
MOB-617: Implement requiresMainQueueSetup

### DIFF
--- a/ios/RNFetchBlob/RNFetchBlob.m
+++ b/ios/RNFetchBlob/RNFetchBlob.m
@@ -42,6 +42,10 @@ dispatch_queue_t fsQueue;
     return rootView.bridge;
 }
 
++ (BOOL)requiresMainQueueSetup {
+    return NO;
+}
+
 RCT_EXPORT_MODULE();
 
 - (id) init {


### PR DESCRIPTION
A year ago we introduced library react-native-fetch-blob into Email Integration feature. AFAIK that feature is still being used today by a select few individuals.

While upgrading to React Native 0.58.5, a yellow box warning shows up.

This PR suppresses that yellow box warning:
```
Module RNFetchBlob requires main queue setup since it overrides `constantsToExport` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.
```
